### PR TITLE
Fix 'System.FormatException: Input string was not in a correct format' problem with parsing RunTime fields

### DIFF
--- a/TransXChange2GTFS_2/Program.cs
+++ b/TransXChange2GTFS_2/Program.cs
@@ -7,6 +7,8 @@ using System.Xml.Serialization;
 using System.Linq;
 using CsvHelper;
 using System.Diagnostics;
+using System.Text.RegularExpressions;
+
 // Reference to GTFS standard https://developers.google.com/transit/gtfs/reference/#agencytxt
 
 namespace TransXChange2GTFS_2
@@ -278,20 +280,14 @@ namespace TransXChange2GTFS_2
                         // For subsequent stops work out the time between stops
                         else
                         {
-                            // Remove the leading and trailing sections of the time leaving only the amount of seconds to add on.
+                            // Extract the number of minutes/seconds to add on from RunTime (in the format "PTnnMnnS")
                             string timeGap = timeGapArray[j - 1].ToString();
-                            if (timeGap.EndsWith("S")== true)
-                            {
-                                string cleanedTimeGap = timeGap.Split(new string[] { "PT" }, StringSplitOptions.None)[1].Replace("S", string.Empty);
-                                int timeIncrease = int.Parse(cleanedTimeGap);
-                                stopsTime = stopsTime.AddSeconds(timeIncrease);
-                            }
-                            else
-                            {
-                                 string cleanedTimeGap = timeGap.Split(new string[] { "PT" }, StringSplitOptions.None)[1].Replace("M", string.Empty);
-                                 int timeIncrease = int.Parse(cleanedTimeGap);
-                                 stopsTime = stopsTime.AddMinutes(timeIncrease);
-                            }
+
+                            var minRegexMatches = Regex.Match(timeGap, @"(\d+)M");
+                            stopsTime = stopsTime.AddMinutes(minRegexMatches.Success ? double.Parse(minRegexMatches.Groups[1].Value) : 0);
+                            var secRegexMatches = Regex.Match(timeGap, @"(\d+)S");
+                            stopsTime = stopsTime.AddSeconds(secRegexMatches.Success ? double.Parse(secRegexMatches.Groups[1].Value) : 0);
+
                             stopTimesArray.Add(stopsTime.ToString("HH:mm:ss"));
                         }
                     }


### PR DESCRIPTION
Hi,

I tried running your neat program against a TransXChange file pulled from the Traveline National Dataset and I hit the following exception:

System.FormatException: Input string was not in a correct format.
   at System.Number.StringToNumber(String str, NumberStyles options, NumberBuffer& number, NumberFormatInfo info, Boolean parseDecimal)
   at System.Number.ParseInt32(String s, NumberStyles style, NumberFormatInfo info)
   at TransXChange2GTFS_2.Program.convertTransXChange2GTFS(String filePath) in F:\Projects\TransXChange2GTFS\TransXChange2GTFS_2\Program.cs:line 286

It looks like the value in cleanedTimeGap at the time in line 286 of Program.cs was "2M17" (which it couldn't parse as an int).
I converted this bit of code to use Regexs instead, which now seems to work against that file.
I hope it helps - thanks again for providing this!
